### PR TITLE
Fixes an Uncaught ReferenceError

### DIFF
--- a/inc/class-wp_recaptcha_ninjaforms.php
+++ b/inc/class-wp_recaptcha_ninjaforms.php
@@ -124,7 +124,7 @@ class WP_reCaptcha_NinjaForms {
 			// reload recaptcha after failed ajax form submit
 			(function($){
 			$(document).on("submitResponse.default", function(e, response){
-				if ( grecaptcha ) {
+				if ( typeof grecaptcha !== "undefined" ) {
 					var wid = $(\'#ninja_forms_form_\'+response.form_id).find(\'.g-recaptcha\').data(\'widget-id\');
 					grecaptcha.reset(wid);
 				}


### PR DESCRIPTION
This is a very low-level defense against a js error when the option not to show the captcha for logged users is on and there is a failure sending the form.
It addresses the issue reported here: https://github.com/mcguffin/wp-recaptcha-integration/issues/62

Probably a better solution would be not to inject the whole code at all if WP_reCaptcha::instance()->is_required() is false, or even at higher level in the wp_recaptcha_do_scripts filter?
but I am not sure about the impact in these cases :)